### PR TITLE
fix(ci): Python 3.9 → 3.11 に更新（requests 2.33.0 が Python >= 3.10 を要求）

### DIFF
--- a/.github/workflows/daily-github-sync.yml
+++ b/.github/workflows/daily-github-sync.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Python環境のセットアップ
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: 依存関係のインストール
         run: |

--- a/.github/workflows/daily-weather-sync.yml
+++ b/.github/workflows/daily-weather-sync.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Python環境のセットアップ
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: 依存関係のインストール
         run: |


### PR DESCRIPTION
dependabot による requests 2.33.0 へのバンプ後、
CI の Python 3.9 環境では Requires-Python >=3.10 制約により
pip install が失敗していた。

https://claude.ai/code/session_013XkFCAFKkfm9LHdR5jRFo3